### PR TITLE
Fix middleware import paths in FileService

### DIFF
--- a/backend/src/services/fileservice.ts
+++ b/backend/src/services/fileservice.ts
@@ -5,8 +5,8 @@ import fs from 'fs/promises'
 import crypto from 'crypto'
 import sharp from 'sharp'
 import { APP_CONSTANTS } from '../utils/constants'
-import { logger } from '../middleware/logger.middleware'
-import { AppError } from '../middleware/error.middleware'
+import { logger } from '../middlewares/logger.middleware'
+import { AppError } from '../middlewares/error.middleware'
 
 // File upload configuration
 interface FileUploadConfig {


### PR DESCRIPTION
## Summary
- use correct `middlewares` path when importing logger and error middleware in FileService

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686094479ec483208971dc31f9597c93