### PR TITLE
Fix logger import path

### DIFF
--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,6 +1,6 @@
 // MAR ABU PROJECTS SERVICES LLC - Database Configuration
 import { PrismaClient } from '@prisma/client'
-import { logger } from '../middleware/logger.middleware'
+import { logger } from '../middlewares/logger.middleware'
 
 // Extend PrismaClient with middleware
 const prismaClientSingleton = () => {


### PR DESCRIPTION
## Summary
- update the logger import path in backend database configuration

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@prisma/client', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68609a2d17388320b877030c7c2a5173